### PR TITLE
Use clojure.core/read to read project.clj and close readers

### DIFF
--- a/src/jarkeeper/core.clj
+++ b/src/jarkeeper/core.clj
@@ -37,19 +37,21 @@
 
 (defn safe-read [s]
   (binding [*read-eval* false]
-    (read-string s)))
+    (read s)))
 
 (defn read-project-clj [repo-owner repo-name]
   (try
     (let [url (str "https://raw.github.com/" repo-owner "/" repo-name "/master/project.clj")]
-      (edn/read (PushbackReader. (io/reader url))))
+      (with-open [rdr (PushbackReader. (io/reader url))]
+        (safe-read rdr)))
     (catch Exception e
       nil)))
 
 (defn read-build-boot [repo-owner repo-name]
   (try
     (let [url (str "https://raw.github.com/" repo-owner "/" repo-name "/master/build.boot")]
-      (safe-read (slurp url)))
+      (with-open [rdr (PushbackReader. (io/reader url))]
+        (safe-read rdr)))
     (catch Exception e
       nil)))
 

--- a/test/jarkeeper/core_test.clj
+++ b/test/jarkeeper/core_test.clj
@@ -1,0 +1,50 @@
+(ns jarkeeper.core-test
+  (:require [clojure.test :refer :all]
+            [jarkeeper.core :refer :all]
+            [clojure.java.io :as io])
+  (:import [java.io PushbackReader]))
+
+(def project-clj-basic "
+(defproject jarkeeper \"0.5.1-SNAPSHOT\"
+  :dependencies [[org.clojure/clojure \"1.6.0\"]])")
+
+(def project-clj-eval "
+(defproject jarkeeper \"0.5.1-SNAPSHOT\"
+  :dependencies [[org.clojure/clojure \"1.6.0\"]]
+  :foo #(throw \"MUST NOT BE EVALUATED\"))")
+
+(deftest read-project-clj-test
+  (is (= '(defproject jarkeeper "0.5.1-SNAPSHOT" :dependencies [[org.clojure/clojure "1.6.0"]])
+         (with-open [rdr (PushbackReader. (io/reader (.getBytes project-clj-basic)))]
+           (safe-read rdr))))
+
+  (is (= '(defproject jarkeeper "0.5.1-SNAPSHOT"
+            :dependencies [[org.clojure/clojure "1.6.0"]]
+            :foo (fn* [] (throw "MUST NOT BE EVALUATED")))
+         (with-open [rdr (PushbackReader. (io/reader (.getBytes project-clj-eval)))]
+           (safe-read rdr)))))
+
+(def build-boot "
+  (set-env! :dependencies [[adzerk-oss/boot-cljs \"1.7.48-6\"]])")
+
+(def build-boot-env-not-first "
+  (println \"foo\")
+  (set-env! :dependencies [[adzerk-oss/boot-cljs \"1.7.48-6\"]])")
+
+(deftest read-boot-deps-test
+  (is (= '((set-env! :dependencies [[adzerk-oss/boot-cljs "1.7.48-6"]]))
+         (with-open [rdr (PushbackReader. (io/reader (.getBytes build-boot)))]
+           (doall (read-file rdr)))))
+
+  (is (= '((println "foo") (set-env! :dependencies [[adzerk-oss/boot-cljs "1.7.48-6"]]))
+         (with-open [rdr (PushbackReader. (io/reader (.getBytes build-boot-env-not-first)))]
+           (doall (read-file rdr))))) )
+
+(deftest read-boot-deps-test
+  (is (= '[adzerk-oss/boot-cljs "1.7.48-6"]
+         (read-boot-deps '((println "foo") (set-env! :dependencies [[adzerk-oss/boot-cljs "1.7.48-6"]])))))
+
+  (testing "read-build-deps can be used when reading"
+    (is (= '[adzerk-oss/boot-cljs "1.7.48-6"]
+           (with-open [rdr (PushbackReader. (io/reader (.getBytes build-boot-env-not-first)))]
+             (read-boot-deps (read-file rdr)))))) )


### PR DESCRIPTION
Project.clj could contain non-edn forms so it needs to be read using clojure.core/read.
Readers should be closed using with-open.

Fixes #15