### PR TITLE
Remove Clojure dependencies from being counted as outdated

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [compojure "1.4.0"]
                  [hiccup "1.0.5"]
                  [ring/ring-defaults "0.1.5"]


### PR DESCRIPTION
Remove Clojure dependencies before counting stats on whether they are up to date or not.

There are lots of reasons why a project doesn't have the latest Clojure version, and there is nothing particularly wrong with that dep being out of date, as a user's own Clojure will take precedence over the one in the dep.
- Update Clojure to 1.8
- Add sift function to simplify the stats calculation code

Fixes #28

**NB: I wasn't sure how to run or test this app, so it will need some testing before going in.**
